### PR TITLE
Add missing Admin SyliusUI import

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,2 +1,3 @@
 imports:
     - { resource: "app/fixtures.yaml" }
+    - { resource: "app/admin/sylius_ui.yaml" }


### PR DESCRIPTION
The field were not correctly displayed in the Channel admin form.
This PR re-enable it.

Note: a Behat test is also required to test this.